### PR TITLE
Add an explicit dependency to PHP_CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         }
     ],
     "require": {
-        "php": "~5.3"
+        "php": "~5.3",
+        "squizlabs/php_codesniffer": "~1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
-        "squizlabs/php_codesniffer": "dev-master"
+        "phpunit/phpunit": "~4.2"
     },
     "target-dir": "ObjectCalisthenics",
     "autoload": {


### PR DESCRIPTION
The repo uses PHP_CodeSniffer classes so the dependency is legitimate.
Thus, it is currently incompatible with the 2.0 version, so it should restrict the allowed version.
Refs #10
