### PR TITLE
Add exceptions for short variables names

### DIFF
--- a/tests/Sniffs/NamingConventions/VariableLengthSniffTest.inc
+++ b/tests/Sniffs/NamingConventions/VariableLengthSniffTest.inc
@@ -8,6 +8,8 @@ class Test
 
     public $veryLongPropertyNameVeryLongPropertyName = 2;
 
+    public $id = 3;
+
     public function __construct($t)
     {
         $this->te = $t;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests?        | yes
| Doc?          | no
| Fixed tickets | https://github.com/object-calisthenics/phpcs-calisthenics-rules/issues/34

### Description

This PR adds a list for accept few short variables names.
See https://github.com/object-calisthenics/phpcs-calisthenics-rules/issues/34 for a more detailed description.