### PR TITLE
Ignore default keyword for switch/case

### DIFF
--- a/src/ObjectCalisthenics/Sniffs/Metrics/OneIndentationLevelSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/OneIndentationLevelSniff.php
@@ -129,10 +129,7 @@ final class OneIndentationLevelSniff implements PHP_CodeSniffer_Sniff
 
     private function handleCaseToken(array $nestedToken)
     {
-        if ($nestedToken['code'] === T_CASE) {
-            // Some tokens needs to be adjusted with a new stack.
-            // Switch and case are considered separated scopes,
-            // incrementing level twice. We need to fix this.
+        if (in_array($nestedToken['code'], [T_CASE, T_DEFAULT])) {
             array_push($this->ignoredScopeStack, $nestedToken);
 
             return;

--- a/tests/Sniffs/Metrics/OneIndentationLevelSniffTest.inc
+++ b/tests/Sniffs/Metrics/OneIndentationLevelSniffTest.inc
@@ -105,4 +105,23 @@ function usingMultipleSwitchInsideLambda()
     $bar();
 }
 
+function usingLambdaDefault()
+{
+    $bar = function ()
+    {
+        switch ($condition) {
+            case '1':
+                echo 'hi';
+
+                break;
+            default:
+                echo 'hi';
+
+                break;
+        }
+    };
+
+    $bar();
+}
+
 ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests?        | yes
| Doc?          | no
| Fixed tickets | https://github.com/object-calisthenics/phpcs-calisthenics-rules/issues/36

### Description

This PR fix a problem with in switch/case.
In fact, this detection comes from `default` keyword.
See https://github.com/object-calisthenics/phpcs-calisthenics-rules/issues/36 for a more detailed description.