### PR TITLE
Class and function length: false positives

### DIFF
--- a/src/ObjectCalisthenics/Sniffs/NamingConventions/ClassLengthSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/NamingConventions/ClassLengthSniff.php
@@ -25,6 +25,16 @@ final class ClassLengthSniff extends AbstractIdentifierLengthSniff implements PH
 
     protected function isValid(PHP_CodeSniffer_File $phpcsFile, int $stackPtr) : bool
     {
-        return $phpcsFile->findPrevious(T_CLASS, ($stackPtr - 1), null, false, null, true) !== false;
+        $previousTClassPosition = $phpcsFile->findPrevious(T_CLASS, ($stackPtr - 1), null, false, null, true);
+        if ($previousTClassPosition === false) {
+            return false;
+        }
+
+        $textAfterTClass = $phpcsFile->getTokensAsString(
+            $previousTClassPosition + 1,
+            $stackPtr - $previousTClassPosition - 1
+        );
+
+        return trim($textAfterTClass) === '';
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/NamingConventions/FunctionLengthSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/NamingConventions/FunctionLengthSniff.php
@@ -25,6 +25,16 @@ final class FunctionLengthSniff extends AbstractIdentifierLengthSniff implements
 
     protected function isValid(PHP_CodeSniffer_File $phpcsFile, int $stackPtr) : bool
     {
-        return $phpcsFile->findPrevious(T_FUNCTION, ($stackPtr - 1), null, false, null, true) !== false;
+        $previousTFunctionPosition = $phpcsFile->findPrevious(T_FUNCTION, ($stackPtr - 1), null, false, null, true);
+        if ($previousTFunctionPosition === false) {
+            return false;
+        }
+
+        $textAfterTFunction = $phpcsFile->getTokensAsString(
+            $previousTFunctionPosition + 1,
+            $stackPtr - $previousTFunctionPosition - 1
+        );
+
+        return trim($textAfterTFunction) === '';
     }
 }

--- a/tests/Sniffs/NamingConventions/ClassLengthSniffTest.inc
+++ b/tests/Sniffs/NamingConventions/ClassLengthSniffTest.inc
@@ -11,3 +11,10 @@ class Te
 class TooMuchLongClassNameTooMuchLongClassNameTooMuchLongClassName
 {
 }
+
+class ValidClassName
+{
+    public function te()
+    {
+    }
+}

--- a/tests/Sniffs/NamingConventions/FunctionLengthSniffTest.inc
+++ b/tests/Sniffs/NamingConventions/FunctionLengthSniffTest.inc
@@ -26,3 +26,7 @@ function te()
 function veryLongFunctionNameVeryLongFunctionName()
 {
 }
+
+class Te
+{
+}


### PR DESCRIPTION
Not (yet) the promised PR about the fluent interfaces but something I found while looking through my errors:

Both the `ClassLengthSniff` and the `FunctionLengthSniff` creating false positives.
They search for a `T_CLASS` / `T_FUNCTION` in the file before their current position and are applied if its found. An example:
```php
class LongEnough {}
function ts() {}
```
In this case **both** the `ClassLengthSniff` and the `FunctionLengthSniff` will mark the `ts` as error.
I added a fix that additionally proves whether the span between the current position and the `T_CLASS` / `T_FUNCTION` contains only whitespaces.

`VariableLengthSniff` is not affected because of the `register()` method. The `ConstantLengthSniff` is also not affected because the local-limitation of File::findPrevious() is effective.