### PR TITLE
Add minimal OneObjectOperatorPerLine config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ This sniff is **configurable**:
 
 - [`ObjectCalisthenics\Sniffs\CodeAnalysis\OneObjectOperatorPerLineSniff`](/src/ObjectCalisthenics\Sniffs\CodeAnalysis\OneObjectOperatorPerLineSniff.php)
 
+This sniff is **configurable**:
+
+```xml
+<!-- ruleset.xml -->
+<rule ref="ObjectCalisthenics.CodeAnalysis.OneObjectOperatorPerLine">
+    <properties>
+        <property name="variablesHoldingAFluentInterface" type="array" value="$queryBuilder"/>
+        <property name="methodsStartingAFluentInterface" type="array" value="createQueryBuilder"/>
+        <property name="methodsEndingAFluentInterface" type="array" value="execute,getQuery"/>
+    </properties>
+</rule>
+```
 
 ### 6. Do not Abbreviate
 


### PR DESCRIPTION
Sorry for the long delay, exams caught me.

Perhaps this configuration needs a little bit more documentation because it is not as self-explaining as the others. Do you have anything against adding some lines of explanation?

See #43 