### PR TITLE
False positive (OneObjectOperatorPerLine) for property access within a class

### DIFF
--- a/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
@@ -94,9 +94,9 @@ final class OneObjectOperatorPerLineSniff implements Sniff
         }
     }
 
-    private function handleExcludedFluentInterfaces(array $tmpToken, string $tmpTokenType): void
+    private function handleExcludedFluentInterfaces(array $tmpToken, string $tmpTokenType, bool $isOwnCall): void
     {
-        if (!$this->callerTokens) {
+        if ((count($this->callerTokens) - (int) $isOwnCall) === 0) {
             return;
         }
 
@@ -154,7 +154,7 @@ final class OneObjectOperatorPerLineSniff implements Sniff
 
             // Look for second object operator token on same statement
             $this->handleTwoObjectOperators($isOwnCall);
-            $this->handleExcludedFluentInterfaces($tmpToken, $tmpTokenType);
+            $this->handleExcludedFluentInterfaces($tmpToken, $tmpTokenType, $isOwnCall);
 
             $this->callerTokens[] = [
                 'token' => $tmpToken,

--- a/tests/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniffTest.inc
+++ b/tests/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniffTest.inc
@@ -23,10 +23,17 @@ class User
     {
         return $this->sessionStorage;
     }
+
+    public function getSessionStorageName()
+    {
+        return $this->sessionStorage->name;
+    }
 }
 
 class MySessionStorage
 {
+    public $name = 'mySessionStorage';
+
     public function __construct()
     {
         $this->driver = new NativeSessionStorage();


### PR DESCRIPTION
When I have something like this:
```php
<?php
class Group
{
    public $id;
}

class User
{
    private $group;

    public function getGroupId()
    {
        return $this->group->id;
    }
}
```
Then I expect no error from the OneObjectOperatorPerLineSniff to occur,
But I got `Only one object operator per line.` at line 13 (`return $this->group->id;`).

The error is triggered in [`Line 113`](https://github.com/object-calisthenics/phpcs-calisthenics-rules/blob/37c8ac842094e7ed34aa46244fe96b6e6e51d5bd/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php#L113). It occurs because `$this->` is counted as first Object Operator. In [`handleTwoObjectOperators`](https://github.com/object-calisthenics/phpcs-calisthenics-rules/blob/37c8ac842094e7ed34aa46244fe96b6e6e51d5bd/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php#L90) this case is excluded by the `$isOwnCall` which tracks whether the starting point is `$this`.

I would suggest to do the same in `handleExcludedFluentInterfaces`. I adjusted at a little bit (because we can have more than 1 callerTokens).
For explanation let's have a look at three examples: `$this->group->id` (which should raise no error), `$user->group->id` (which should raise an error) and `$this->user->group->id` (which should also raise an error):

|                          | `$callerTokens` (simplified) | `count($callerTokens)` | `$isOwnCall` | Early exit? |
|--------------------------|------------------------------|------------------------|--------------|-------------|
| `$this->group->id`       | `['group']`                  | `1`                    | `true`       | Yes         |
| `$user->group->id`       | `['group']`                  | `1`                    | `false`      | No          |
| `$this->user->group->id` | `['user', 'group']`          | `2`                    | `true`       | No          |

This could be handled by the following check:
```php
if ((count($this->callerTokens) - (int) $isOwnCall) === 0) {
    return;
}
```