### PR TITLE
Fixed error message for MaxNestingLevelSniff

### DIFF
--- a/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
@@ -8,9 +8,9 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * MaxNestingLevelSniff
+ * MaxNestingLevelSniff.
  *
- * @uses Sniff
+ * @uses \Sniff
  */
 final class MaxNestingLevelSniff implements Sniff
 {
@@ -79,7 +79,6 @@ final class MaxNestingLevelSniff implements Sniff
 
     /**
      * @param int $nestingLevel
-     * @return void
      */
     private function handleNestingLevel(int $nestingLevel): void
     {
@@ -95,10 +94,9 @@ final class MaxNestingLevelSniff implements Sniff
     }
 
     /**
-     * @param int $start
-     * @param int $end
+     * @param int   $start
+     * @param int   $end
      * @param array $tokens
-     * @return void
      */
     private function iterateTokens(int $start, int $end, array $tokens): void
     {
@@ -114,7 +112,6 @@ final class MaxNestingLevelSniff implements Sniff
 
     /**
      * @param array $nestedToken
-     * @return void
      */
     private function handleToken(array $nestedToken): void
     {
@@ -133,6 +130,7 @@ final class MaxNestingLevelSniff implements Sniff
 
     /**
      * @param array $token
+     *
      * @return int
      */
     private function subtractFunctionNestingLevel(array $token): int
@@ -142,7 +140,6 @@ final class MaxNestingLevelSniff implements Sniff
 
     /**
      * @param array $nestedToken
-     * @return void
      */
     private function handleClosureToken(array $nestedToken)
     {
@@ -157,7 +154,6 @@ final class MaxNestingLevelSniff implements Sniff
 
     /**
      * @param array $nestedToken
-     * @return void
      */
     private function handleCaseToken(array $nestedToken): void
     {
@@ -168,9 +164,6 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @return void
-     */
     private function adjustNestingLevelToIgnoredScope(): void
     {
         // Iterated through ignored scope stack to find out if
@@ -181,9 +174,8 @@ final class MaxNestingLevelSniff implements Sniff
     }
 
     /**
-     * @param int $key
+     * @param int   $key
      * @param array $ignoredScope
-     * @return void
      */
     private function unsetScopeIfNotCurrent(int $key, array $ignoredScope): void
     {

--- a/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace ObjectCalisthenics\Sniffs\Metrics;
 
@@ -9,8 +7,6 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * MaxNestingLevelSniff.
- *
- * @uses \Sniff
  */
 final class MaxNestingLevelSniff implements Sniff
 {
@@ -45,7 +41,7 @@ final class MaxNestingLevelSniff implements Sniff
     private $currentPtr;
 
     /**
-     * @return array
+     * @return int[]
      */
     public function register(): array
     {
@@ -77,9 +73,6 @@ final class MaxNestingLevelSniff implements Sniff
         $this->handleNestingLevel($this->nestingLevel);
     }
 
-    /**
-     * @param int $nestingLevel
-     */
     private function handleNestingLevel(int $nestingLevel): void
     {
         if ($nestingLevel > $this->maxNestingLevel) {
@@ -93,11 +86,6 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @param int   $start
-     * @param int   $end
-     * @param array $tokens
-     */
     private function iterateTokens(int $start, int $end, array $tokens): void
     {
         $this->currentPtr = $start + 1;
@@ -110,9 +98,6 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @param array $nestedToken
-     */
     private function handleToken(array $nestedToken): void
     {
         $this->handleClosureToken($nestedToken);
@@ -128,19 +113,11 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @param array $token
-     *
-     * @return int
-     */
     private function subtractFunctionNestingLevel(array $token): int
     {
         return $this->nestingLevel - $token['level'] - 1;
     }
 
-    /**
-     * @param array $nestedToken
-     */
     private function handleClosureToken(array $nestedToken)
     {
         if ($nestedToken['code'] === T_CLOSURE) {
@@ -152,9 +129,6 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @param array $nestedToken
-     */
     private function handleCaseToken(array $nestedToken): void
     {
         if (in_array($nestedToken['code'], [T_CASE, T_DEFAULT])) {
@@ -173,10 +147,6 @@ final class MaxNestingLevelSniff implements Sniff
         }
     }
 
-    /**
-     * @param int   $key
-     * @param array $ignoredScope
-     */
     private function unsetScopeIfNotCurrent(int $key, array $ignoredScope): void
     {
         if ($ignoredScope['scope_closer'] !== $this->currentPtr) {

--- a/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
@@ -5,9 +5,6 @@ namespace ObjectCalisthenics\Sniffs\Metrics;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-/**
- * MaxNestingLevelSniff.
- */
 final class MaxNestingLevelSniff implements Sniff
 {
     /**


### PR DESCRIPTION
- fixed hardcoded max nesting level in error message
- added pluralization for level if maxNestingLevel > 1
- phpDoc