### PR TITLE
Composer: Add type as phpcodesniffer-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "object-calisthenics/phpcs-calisthenics-rules",
     "description": "PHP CodeSniffer Object Calisthenics rules/sniffs",
     "license": "MIT",
+    "type": "phpcodesniffer-standard",
     "homepage": "https://github.com/object-calisthenics/phpcs-calisthenics-rules",
     "authors": [
         { "name": "Guilherme Blanco", "email": "guilhermeblanco@hotmail.com" },


### PR DESCRIPTION
This can be used by several Composer plugins to automatically register a standard with the local install of PHP CodeSniffer.

Fixes #69.