### PR TITLE
Small typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ foreach ($sniffGroups as $sniffGroup) {
 
 ```php
 foreach ($sniffGroups as $sniffGroup) {
-    $this->ensureIsAllInstanceOf($sniffGefroup, Sniff::class);
+    $this->ensureIsAllInstanceOf($sniffGroup, Sniff::class);
 }
 
 // ...
@@ -319,11 +319,11 @@ class ImmutableBankAccount
 
 ### Not Implemented Rules - Too Strict, Vague or Annoying
 
-While using in practise, we found these rule to be too strict, vague or even annoying, rather then helping to write cleaner and more pragmatic code. They're also closely related with [Domain Driven Design](https://github.com/dddinphp).
+While using in practice, we found these rule to be too strict, vague or even annoying, rather than helping to write cleaner and more pragmatic code. They're also closely related with [Domain Driven Design](https://github.com/dddinphp).
 
 **3. [Wrap Primitive Types and Strings](http://williamdurand.fr/2013/06/03/object-calisthenics/#3-wrap-all-primitives-and-strings)** - Since PHP 7, you can use `define(strict_types=1)` and scalar type hints. For other cases, e.g. email, you can deal with that in your [Domain via Value Objects](http://williamdurand.fr/2013/06/03/object-calisthenics/#3-wrap-all-primitives-and-strings).
 
-**4. [Use First Class Collections](http://williamdurand.fr/2013/06/03/object-calisthenics/#4-first-class-collections)** - This rule makes sense, yet is too strict to be useful in practise. Even our code didn't pass it at all.
+**4. [Use First Class Collections](http://williamdurand.fr/2013/06/03/object-calisthenics/#4-first-class-collections)** - This rule makes sense, yet is too strict to be useful in practice. Even our code didn't pass it at all.
 
 **8. [Do Not Use Classes With More Than Two Instance Variables](http://williamdurand.fr/2013/06/03/object-calisthenics/#8-no-classes-with-more-than-two-instance-variables)** -
 This depends on individual domain of each project. It doesn't make sense to make a rule for that.


### PR DESCRIPTION
- Fix variable name typo in code example.
- Opt for US English, which seems the project default.
- Tiny [grammar fix](https://www.quora.com/Which-is-correct-Sooner-rather-then-than-later)