### PR TITLE
add addslashes function in every addError method to fix phpcs json reports

### DIFF
--- a/src/ObjectCalisthenics/Sniffs/Classes/ForbiddenPublicPropertySniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Classes/ForbiddenPublicPropertySniff.php
@@ -40,7 +40,7 @@ final class ForbiddenPublicPropertySniff implements Sniff
 
         $scopeModifierToken = $this->getPropertyScopeModifier($file, $position);
         if ($scopeModifierToken['code'] === T_PUBLIC) {
-            $file->addError(self::ERROR_MESSAGE, $position, self::class);
+            $file->addError(self::ERROR_MESSAGE, $position, addslashes(self::class));
         }
     }
 

--- a/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
@@ -102,7 +102,7 @@ final class OneObjectOperatorPerLineSniff implements Sniff
     private function handleTwoObjectOperators(bool $isOwnCall): void
     {
         if ($this->callerTokens && ! $isOwnCall && ! $this->isInFluentInterfaceMode()) {
-            $this->file->addError(self::ERROR_MESSAGE, $this->position, self::class);
+            $this->file->addError(self::ERROR_MESSAGE, $this->position, addslashes(self::class));
         }
     }
 
@@ -125,7 +125,7 @@ final class OneObjectOperatorPerLineSniff implements Sniff
             && $memberTokenCount > 1 && $tmpToken['content'] !== $memberToken['token']['content']
             && ! $this->isInFluentInterfaceMode())
         ) {
-            $this->file->addError(self::ERROR_MESSAGE, $this->position, self::class);
+            $this->file->addError(self::ERROR_MESSAGE, $this->position, addslashes(self::class));
         }
     }
 

--- a/src/ObjectCalisthenics/Sniffs/ControlStructures/NoElseSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/ControlStructures/NoElseSniff.php
@@ -26,6 +26,6 @@ final class NoElseSniff implements Sniff
      */
     public function process(File $file, $position): void
     {
-        $file->addError(self::ERROR_MESSAGE, $position, self::class);
+        $file->addError(self::ERROR_MESSAGE, $position, addslashes(self::class));
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/Files/ClassTraitAndInterfaceLengthSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Files/ClassTraitAndInterfaceLengthSniff.php
@@ -36,7 +36,7 @@ final class ClassTraitAndInterfaceLengthSniff implements Sniff
 
         if ($length > $this->maxLength) {
             $error = sprintf(self::ERROR_MESSAGE, $length, $this->maxLength);
-            $file->addError($error, $position, self::class);
+            $file->addError($error, $position, addslashes(self::class));
         }
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/Files/FunctionLengthSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Files/FunctionLengthSniff.php
@@ -36,7 +36,7 @@ final class FunctionLengthSniff implements Sniff
 
         if ($length > $this->maxLength) {
             $error = sprintf(self::ERROR_MESSAGE, $length, $this->maxLength);
-            $file->addError($error, $position, self::class);
+            $file->addError($error, $position, addslashes(self::class));
         }
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/MaxNestingLevelSniff.php
@@ -87,7 +87,7 @@ final class MaxNestingLevelSniff implements Sniff
                 $nestingLevel
             );
 
-            $this->file->addError($error, $this->position, self::class);
+            $this->file->addError($error, $this->position, addslashes(self::class));
         }
     }
 

--- a/src/ObjectCalisthenics/Sniffs/Metrics/MethodPerClassLimitSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/MethodPerClassLimitSniff.php
@@ -44,7 +44,7 @@ final class MethodPerClassLimitSniff implements Sniff
                 $this->maxCount
             );
 
-            $file->addError($message, $position, self::class);
+            $file->addError($message, $position, addslashes(self::class));
         }
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/Metrics/PropertyPerClassLimitSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/Metrics/PropertyPerClassLimitSniff.php
@@ -43,7 +43,7 @@ final class PropertyPerClassLimitSniff implements Sniff
                 $propertiesCount,
                 $this->maxCount
             );
-            $file->addError($message, $position, self::class);
+            $file->addError($message, $position, addslashes(self::class));
         }
     }
 }

--- a/src/ObjectCalisthenics/Sniffs/NamingConventions/ElementNameMinimalLengthSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/NamingConventions/ElementNameMinimalLengthSniff.php
@@ -52,7 +52,7 @@ final class ElementNameMinimalLengthSniff implements Sniff
             $elementNameLength,
             $this->minLength
         );
-        $file->addError($message, $position, self::class);
+        $file->addError($message, $position, addslashes(self::class));
     }
 
     private function shouldBeSkipped(int $elementNameLength, string $elementName): bool

--- a/src/ObjectCalisthenics/Sniffs/NamingConventions/NoSetterSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/NamingConventions/NoSetterSniff.php
@@ -38,7 +38,7 @@ final class NoSetterSniff implements Sniff
         }
 
         if ($this->methodNameStartsWithSet($declarationName)) {
-            $file->addError(self::ERROR_MESSAGE, $position, self::class);
+            $file->addError(self::ERROR_MESSAGE, $position, addslashes(self::class));
         }
     }
 


### PR DESCRIPTION
I use [Visual Studio Code](https://github.com/Microsoft/vscode) with [phpcs extension](https://github.com/ikappas/vscode-phpcs), but your sniffer didn't work. The extension uses the json report of phpcs (e.g. phpcs src --report=json) and your sniffer generates invalid json, because of the (not escaped) backslashes in the namespace.