### PR TITLE
Support Slevomat conding standard v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.3",
         "nette/utils": "^2.5",
-        "slevomat/coding-standard": "^4.8 || ^5.0"
+        "slevomat/coding-standard": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.3",
         "nette/utils": "^2.5",
-        "slevomat/coding-standard": "^4.8"
+        "slevomat/coding-standard": "^4.8 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
Should not cause any issue as your ruleset does not set any rules from Slevomat.

BTW, why requiring it? It can apparently be installed separately.