### PR TITLE
Allow the usage of nette/utils ^3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.4",
-        "nette/utils": "^2.5",
+        "nette/utils": "^2.5|^3.0",
         "slevomat/coding-standard": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi!

I arrived here after I tried to add [nunomaduro/phpinsights](https://github.com/nunomaduro/phpinsights) to an existing project that already had `nette/utils` installed, but in Release 3.0.1

I'd like to propose changing the requirement to `^2.5|^3.0`. As far as I can tell, currently only `Nette\Utils\Strings` is used and this hasn't changed between the releases.

:octocat: 