### PR TITLE
Fix the CI on PHP 7.4

### DIFF
--- a/ecs.yaml
+++ b/ecs.yaml
@@ -34,6 +34,8 @@ parameters:
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff.FoundInWhileCondition: ~
 
         Symplify\CodingStandard\Sniffs\CleanCode\ForbiddenStaticFunctionSniff: ~
+        Symplify\CodingStandard\Sniffs\CleanCode\CognitiveComplexitySniff:
+            - '*src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php'
         # Symfony ruleset
         PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer: ~
         PhpCsFixer\Fixer\Operator\NewWithBracesFixer: ~

--- a/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
+++ b/src/ObjectCalisthenics/Sniffs/CodeAnalysis/OneObjectOperatorPerLineSniff.php
@@ -141,11 +141,13 @@ final class OneObjectOperatorPerLineSniff implements Sniff
 
         $memberTokenCount = count($this->callerTokens);
         $memberToken = end($this->callerTokens);
-        $memberTokenType = $memberToken['type'];
+        if ($memberToken === false) {
+            return;
+        }
 
-        if (($memberTokenType === 'property' && $tmpTokenType === 'property')
-            || ($memberTokenType === 'method' && $tmpTokenType === 'property')
-            || ($memberTokenType === 'method' && $tmpTokenType === 'method'
+        if (($memberToken['type'] === 'property' && $tmpTokenType === 'property')
+            || ($memberToken['type'] === 'method' && $tmpTokenType === 'property')
+            || ($memberToken['type'] === 'method' && $tmpTokenType === 'method'
             && $memberTokenCount > 1 && $tmpToken['content'] !== $memberToken['token']['content']
             && ! $this->isInFluentInterfaceMode())
         ) {


### PR DESCRIPTION
@TomasVotruba In PHP 7.4 we must ensure that the `end` function don't return false on this slice of code. I try in 2 different way but in one side the cognitive complexity become too hard (9 > 8). In another side, the class become too long (207 lines) and there is 11 methods instead of 10.

Any advice on the way to do it ?