### PR TITLE
[README] Add deprecation notice and link to PHPStan rule set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Object Calisthenics rules for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 
+
+**DEPRECATED: PHP_CodeSniffer is great for handling spaces and char positions. Yet these rules are about code architecture and structure. In 2020, there is tool that suits this perfectly - [PHPStan](github.com/phpstan/phpstan)**.
+
+**Saying that, [object calisthenics were implemented as PHPStan rules](https://github.com/symplify/coding-standard/blob/master/docs/phpstan_rules_object_calisthenics.md) in a  `symplify/coding-standard` package. Use it instead.**
+
+<br>
+<br>
+<br>
+
 [![Downloads](https://img.shields.io/packagist/dt/object-calisthenics/phpcs-calisthenics-rules.svg?style=flat-square)](https://packagist.org/packages/object-calisthenics/phpcs-calisthenics-rules)
 
 Object Calisthenics are **set of rules in object-oriented code, that focuses of maintainability, readability, testability and comprehensibility**. We're **pragmatic first** - they are easy to use all together or one by one.


### PR DESCRIPTION
This is not a normal deprecation, but rather a replacement 1:1 with better tool.

PHP_CodeSniffer is great for handling spaces and char positions. Yet these rules are about code architecture and structure. In 2020, there is tool that suits this perfectly - [PHPStan](github.com/phpstan/phpstan).

Saying that, [object calisthenics were implemented as PHPStan rules](https://github.com/symplify/coding-standard/blob/master/docs/phpstan_rules_object_calisthenics.md) in a  `symplify/coding-standard` package. It should be used instead.

<br>

---

<br>

cc @guilhermeblanco Hi Guilherme, I know you're not active much here, but still I think you should know. Let me know if this move is ok for you. 
Not much really changes, rules just work much better now as PHPStan doesn't deal with spacing bugs.